### PR TITLE
fix:remove ItemType property

### DIFF
--- a/FPIS/Migrations/20230215133158_RemoveItemTypeFromProductParameterModel.Designer.cs
+++ b/FPIS/Migrations/20230215133158_RemoveItemTypeFromProductParameterModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FPIS.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FPIS.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230215133158_RemoveItemTypeFromProductParameterModel")]
+    partial class RemoveItemTypeFromProductParameterModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FPIS/Migrations/20230215133158_RemoveItemTypeFromProductParameterModel.cs
+++ b/FPIS/Migrations/20230215133158_RemoveItemTypeFromProductParameterModel.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FPIS.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveItemTypeFromProductParameterModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ItemType",
+                table: "ProductParameters");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ItemType",
+                table: "ProductParameters",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/FPIS/Models/ProductParameter.cs
+++ b/FPIS/Models/ProductParameter.cs
@@ -17,7 +17,6 @@ namespace FPIS.Models
         public string Unit { get; set; }
         public string Method { get; set; }
         public float Specification { get; set; }
-        public string ItemType { get; set; }
 
         // Navigation Properties
         public List<ProductAnalysisParameter> ProductAnalysisParameters { get; set; }


### PR DESCRIPTION
database was updated to break down Parameter details. ItemType was used earlier to tell what kind of parameter a record was. Seperate models were created for Water and Product so ItemType isn't needed