### PR TITLE
Add Product Name To Material Issue Form

### DIFF
--- a/FPIS/Models/AnalysisRawMaterialsSampleBindingItem.cs
+++ b/FPIS/Models/AnalysisRawMaterialsSampleBindingItem.cs
@@ -17,5 +17,6 @@
         public string Location { get; set; }
         public string Lot { get; set; }
         public string AnalysisStatus { get; set; }
+        public string ProductName { get; set; }
     }
 }

--- a/FPIS/Views/AddRawMaterialsAnalysisSampleForm.Designer.cs
+++ b/FPIS/Views/AddRawMaterialsAnalysisSampleForm.Designer.cs
@@ -31,15 +31,16 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AddRawMaterialsAnalysisSampleForm));
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.analysisRawMaterialsSampleBindingItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.analysisSampleBindingItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.DateAdded = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ProductName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ProcurementLocationId = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.QuantityReceived = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.QuantityLeft = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Location = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Lot = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.selectedDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.analysisRawMaterialsSampleBindingItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.analysisSampleBindingItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.analysisRawMaterialsSampleBindingItemBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.analysisSampleBindingItemBindingSource)).BeginInit();
@@ -54,6 +55,7 @@
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.DateAdded,
+            this.ProductName,
             this.ProcurementLocationId,
             this.QuantityReceived,
             this.QuantityLeft,
@@ -70,6 +72,14 @@
             this.dataGridView1.TabIndex = 0;
             this.dataGridView1.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellClick);
             // 
+            // analysisRawMaterialsSampleBindingItemBindingSource
+            // 
+            this.analysisRawMaterialsSampleBindingItemBindingSource.DataSource = typeof(FPIS.Models.AnalysisRawMaterialsSampleBindingItem);
+            // 
+            // analysisSampleBindingItemBindingSource
+            // 
+            this.analysisSampleBindingItemBindingSource.DataSource = typeof(FPIS.Models.AnalysisSampleBindingItem);
+            // 
             // DateAdded
             // 
             this.DateAdded.DataPropertyName = "DateAdded";
@@ -78,6 +88,13 @@
             this.DateAdded.Name = "DateAdded";
             this.DateAdded.ReadOnly = true;
             this.DateAdded.Width = 114;
+            // 
+            // ProductName
+            // 
+            this.ProductName.DataPropertyName = "ProductName";
+            this.ProductName.HeaderText = "ProductName";
+            this.ProductName.Name = "ProductName";
+            this.ProductName.ReadOnly = true;
             // 
             // ProcurementLocationId
             // 
@@ -128,14 +145,6 @@
             this.selectedDataGridViewCheckBoxColumn.ReadOnly = true;
             this.selectedDataGridViewCheckBoxColumn.Width = 114;
             // 
-            // analysisRawMaterialsSampleBindingItemBindingSource
-            // 
-            this.analysisRawMaterialsSampleBindingItemBindingSource.DataSource = typeof(FPIS.Models.AnalysisRawMaterialsSampleBindingItem);
-            // 
-            // analysisSampleBindingItemBindingSource
-            // 
-            this.analysisSampleBindingItemBindingSource.DataSource = typeof(FPIS.Models.AnalysisSampleBindingItem);
-            // 
             // AddRawMaterialsAnalysisSampleForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -167,6 +176,7 @@
         private DataGridViewTextBoxColumn Remarks;
         private DataGridViewTextBoxColumn AnalysisStatus;
         private DataGridViewTextBoxColumn DateAdded;
+        private DataGridViewTextBoxColumn ProductName;
         private DataGridViewTextBoxColumn ProcurementLocationId;
         private DataGridViewTextBoxColumn QuantityReceived;
         private DataGridViewTextBoxColumn QuantityLeft;

--- a/FPIS/Views/AddRawMaterialsAnalysisSampleForm.cs
+++ b/FPIS/Views/AddRawMaterialsAnalysisSampleForm.cs
@@ -17,8 +17,8 @@ namespace FPIS.Views
         public AddRawMaterialsAnalysisSampleForm()
         {
             InitializeComponent();
-            Theme.FormInstance = this;
-            Theme.Set(Themes.LIGHT);
+            //Theme.FormInstance = this;
+            //Theme.Set(Themes.LIGHT);
             dataGridView1.DataSource = itemList;
 
             selectedSamples = ProcurementIssueMaterials.analysisItemList.ToArray();
@@ -75,7 +75,8 @@ namespace FPIS.Views
                             Lot = procurementLocation.Lot,
                             Supplier = materialReceived.Supplier,
                             TruckNumber = materialReceived.TruckNumber,
-                            Selected = existingItem != null
+                            Selected = existingItem != null,
+                            ProductName = analysisProduct.Product.ProductName
                         };
 
                         itemList.Add(newItem);
@@ -110,7 +111,7 @@ namespace FPIS.Views
 
 
             // only react if the user clicked on the select item column
-            if (e.ColumnIndex != 6)
+            if (e.ColumnIndex != 7)
             {
                 return;
             }

--- a/FPIS/Views/AddRawMaterialsAnalysisSampleForm.cs
+++ b/FPIS/Views/AddRawMaterialsAnalysisSampleForm.cs
@@ -17,8 +17,8 @@ namespace FPIS.Views
         public AddRawMaterialsAnalysisSampleForm()
         {
             InitializeComponent();
-            //Theme.FormInstance = this;
-            //Theme.Set(Themes.LIGHT);
+            Theme.FormInstance = this;
+            Theme.Set(Themes.LIGHT);
             dataGridView1.DataSource = itemList;
 
             selectedSamples = ProcurementIssueMaterials.analysisItemList.ToArray();

--- a/FPIS/Views/AddRawMaterialsAnalysisSampleForm.resx
+++ b/FPIS/Views/AddRawMaterialsAnalysisSampleForm.resx
@@ -60,6 +60,9 @@
   <metadata name="DateAdded.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="ProductName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="ProcurementLocationId.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>


### PR DESCRIPTION
Added the Product Name field to the raw materials issued form to help Production engineers experience when issuing raw materials.

Previous system UI:
![image](https://github.com/EugeneAgyemang/FPIS/assets/104218489/3221e83a-8bb7-43d0-80b5-4d17db7805cc)

Changes would produce:
![image](https://github.com/EugeneAgyemang/FPIS/assets/104218489/a5711668-4478-4c2f-83f3-a612be18dde4)

