### PR TITLE
Display Analytical Results for the current day by Default

### DIFF
--- a/FPIS/Services/AnalysisService.cs
+++ b/FPIS/Services/AnalysisService.cs
@@ -33,6 +33,18 @@ namespace FPIS.Services
                 .ToList();
         }
 
+        public List<SampleResult> FetchProductSampleResultsForToday(DateOnly fromDate, DateOnly toDate)
+        {
+            return _dbContext.SampleResults
+                .OrderByDescending(s => s.Date)
+                .OrderByDescending(s => s.Time)
+                .Include(sr => sr.Sample)
+                .Where(sr => sr.Sample.TypeForFiltering == "Production")
+                .Where(sr => sr.Sample.Date >= fromDate && sr.Sample.Date <= toDate)
+                .Include(sr => sr.User)
+                .ToList();
+        }
+
         public List<SampleResult> FetchProductSampleResultsByDate(DateOnly fromDate, DateOnly toDate)
         {
             return _dbContext.SampleResults
@@ -64,6 +76,19 @@ namespace FPIS.Services
                 .OrderByDescending(s => s.Time)
                 .Include(sr => sr.Sample)
                 .Where(sr => sr.Sample.TypeForFiltering == "Water")
+                .Include(sr => sr.User)
+                .ToList();
+        }
+
+
+        public List<SampleResult> FetchWaterSampleResultsForToday(DateOnly fromDate, DateOnly toDate)
+        {
+            return _dbContext.SampleResults
+                .OrderByDescending(s => s.Date)
+                .OrderByDescending(s => s.Time)
+                .Include(sr => sr.Sample)
+                .Where(sr => sr.Sample.TypeForFiltering == "Water")
+                .Where(sr => sr.Sample.Date >= fromDate && sr.Sample.Date <= toDate)
                 .Include(sr => sr.User)
                 .ToList();
         }

--- a/FPIS/Services/Product.Service.cs
+++ b/FPIS/Services/Product.Service.cs
@@ -122,6 +122,34 @@ namespace FPIS.Services
 
         }
 
+        public List<SampleDetail> GetProductsWithAnalysisResultsForToday(DateOnly fromDate, DateOnly toDate, string productName = "")
+        {
+            IQueryable<SampleDetail> productSamplesRequestedQuery = _dbContext.SampleDetails.
+                Include(sd => sd.Sample).
+                Where(a => a.Sample.Date >= fromDate && a.Sample.Date <= toDate).
+                Where(a => a.Sample.Status != "Pending").
+                Where(a => a.AnalysisItem.ItemType == "Product").
+                OrderByDescending(sample => sample.Sample.Date).
+                ThenByDescending(sample => sample.Sample.Time).
+                Include(analysisItem => analysisItem.AnalysisItem.AnalysisProducts).
+                ThenInclude(analysisProduct => analysisProduct.Product.ProductParameters).
+                ThenInclude(a => a.ProductAnalysisParameters).
+                ThenInclude(a => a.AnalysisParameter.sampleResultsDetailsWithParameters).
+                ThenInclude(a => a.SampleResultDetail.SampleResult);
+
+
+            if (productName != string.Empty)
+            {
+                productSamplesRequestedQuery = productSamplesRequestedQuery.
+                Where(a => a.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductName == productName);
+
+            }
+
+
+            return productSamplesRequestedQuery.ToList();
+
+        }
+
         public List<SampleDetail> GetProductsWithAnalysisResultsPerDate(DateOnly fromDate, DateOnly toDate, string productName = "")
         {
             IQueryable<SampleDetail> productSamplesRequestedQuery = _dbContext.SampleDetails.

--- a/FPIS/Services/WaterService.cs
+++ b/FPIS/Services/WaterService.cs
@@ -105,6 +105,34 @@ namespace FPIS.Services
 
         }
 
+        public List<SampleDetail> GetWatersWithAnalysisResultsForToday(DateOnly fromDate, DateOnly toDate, string waterName = "")
+        {
+            IQueryable<SampleDetail> waterSamplesRequestedQuery = _dbContext.SampleDetails.
+                Include(sd => sd.Sample).
+                Where(a => a.Sample.Date >= fromDate && a.Sample.Date <= toDate).
+                Where(a => a.Sample.Status != "Pending").
+                Where(a => a.AnalysisItem.ItemType == "Water").
+                OrderByDescending(sample => sample.Sample.Date).
+                ThenByDescending(sample => sample.Sample.Time).
+                Include(analysisItem => analysisItem.AnalysisItem.AnalysisWaters).
+                ThenInclude(analysisWater => analysisWater.Water.WaterParameters).
+                ThenInclude(a => a.WaterAnalysisParameters).
+                ThenInclude(a => a.AnalysisParameter.sampleResultsDetailsWithParameters).
+                ThenInclude(a => a.SampleResultDetail.SampleResult);
+
+
+            if (waterName != string.Empty)
+            {
+                waterSamplesRequestedQuery = waterSamplesRequestedQuery.
+                Where(a => a.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductName == waterName);
+
+            }
+
+
+            return waterSamplesRequestedQuery.ToList();
+
+        }
+
         public List<SampleDetail> GetWatersWithAnalysisResultsPerDate(DateOnly fromDate, DateOnly toDate, string waterName = "")
         {
             IQueryable<SampleDetail> waterSamplesRequestedQuery = _dbContext.SampleDetails.

--- a/FPIS/Views/AnalysisCalculatorForm.Designer.cs
+++ b/FPIS/Views/AnalysisCalculatorForm.Designer.cs
@@ -905,7 +905,7 @@
             materialTextBoxMassOfExtractedOil.BorderStyle = BorderStyle.None;
             materialTextBoxMassOfExtractedOil.Depth = 0;
             materialTextBoxMassOfExtractedOil.Font = new Font("Roboto", 16F, FontStyle.Regular, GraphicsUnit.Pixel);
-            materialTextBoxMassOfExtractedOil.Hint = "Mass of Extracted Oil";
+            materialTextBoxMassOfExtractedOil.Hint = "Mass of Empty Glassware";
             materialTextBoxMassOfExtractedOil.LeadingIcon = null;
             materialTextBoxMassOfExtractedOil.Location = new Point(42, 202);
             materialTextBoxMassOfExtractedOil.MaxLength = 50;
@@ -1143,7 +1143,7 @@
             AutoScaleMode = AutoScaleMode.Font;
             AutoScroll = true;
             AutoScrollMinSize = new Size(0, 1096);
-            ClientSize = new Size(1370, 1102);
+            ClientSize = new Size(1388, 1102);
             Controls.Add(groupBox7);
             Controls.Add(groupBox6);
             Controls.Add(groupBox5);

--- a/FPIS/Views/Startup.Designer.cs
+++ b/FPIS/Views/Startup.Designer.cs
@@ -28,101 +28,100 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Startup));
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.Caption = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.panel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.SuspendLayout();
+            panel1 = new Panel();
+            label3 = new Label();
+            label2 = new Label();
+            Caption = new Label();
+            pictureBox1 = new PictureBox();
+            timer1 = new System.Windows.Forms.Timer(components);
+            panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
+            SuspendLayout();
             // 
             // panel1
             // 
-            this.panel1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(97)))), ((int)(((byte)(46)))));
-            this.panel1.Controls.Add(this.label3);
-            this.panel1.Controls.Add(this.label2);
-            this.panel1.Controls.Add(this.Caption);
-            this.panel1.Controls.Add(this.pictureBox1);
-            this.panel1.Location = new System.Drawing.Point(53, 67);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(544, 266);
-            this.panel1.TabIndex = 5;
+            panel1.BackColor = Color.FromArgb(63, 97, 46);
+            panel1.Controls.Add(label3);
+            panel1.Controls.Add(label2);
+            panel1.Controls.Add(Caption);
+            panel1.Controls.Add(pictureBox1);
+            panel1.Location = new Point(53, 67);
+            panel1.Name = "panel1";
+            panel1.Size = new Size(544, 266);
+            panel1.TabIndex = 5;
             // 
             // label3
             // 
-            this.label3.AutoSize = true;
-            this.label3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(97)))), ((int)(((byte)(46)))));
-            this.label3.Font = new System.Drawing.Font("Roboto", 22F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-            this.label3.ForeColor = System.Drawing.Color.White;
-            this.label3.Location = new System.Drawing.Point(18, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(514, 27);
-            this.label3.TabIndex = 6;
-            this.label3.Text = "FRACTIONATION PROCESS INTEGRATION SYSTEM";
+            label3.AutoSize = true;
+            label3.BackColor = Color.FromArgb(63, 97, 46);
+            label3.Font = new Font("Microsoft Sans Serif", 22F, FontStyle.Regular, GraphicsUnit.Pixel);
+            label3.ForeColor = Color.White;
+            label3.Location = new Point(18, 0);
+            label3.Name = "label3";
+            label3.Size = new Size(610, 29);
+            label3.TabIndex = 6;
+            label3.Text = "FRACTIONATION PROCESS INTEGRATION SYSTEM";
             // 
             // label2
             // 
-            this.label2.AutoSize = true;
-            this.label2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(97)))), ((int)(((byte)(46)))));
-            this.label2.Font = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-            this.label2.ForeColor = System.Drawing.Color.White;
-            this.label2.Location = new System.Drawing.Point(202, 248);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(147, 14);
-            this.label2.TabIndex = 4;
-            this.label2.Text = "Powered by ITS Gh. v1.0.1";
+            label2.AutoSize = true;
+            label2.BackColor = Color.FromArgb(63, 97, 46);
+            label2.Font = new Font("Microsoft Sans Serif", 12F, FontStyle.Regular, GraphicsUnit.Pixel);
+            label2.ForeColor = Color.White;
+            label2.Location = new Point(199, 248);
+            label2.Name = "label2";
+            label2.Size = new Size(163, 16);
+            label2.TabIndex = 4;
+            label2.Text = "Powered by ITS Gh. v1.0.9";
             // 
             // Caption
             // 
-            this.Caption.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(97)))), ((int)(((byte)(46)))));
-            this.Caption.Font = new System.Drawing.Font("Roboto", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-            this.Caption.ForeColor = System.Drawing.Color.White;
-            this.Caption.Location = new System.Drawing.Point(241, 39);
-            this.Caption.Name = "Caption";
-            this.Caption.Size = new System.Drawing.Size(300, 26);
-            this.Caption.TabIndex = 3;
-            this.Caption.Text = "Loading";
-            this.Caption.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            Caption.BackColor = Color.FromArgb(63, 97, 46);
+            Caption.Font = new Font("Microsoft Sans Serif", 14F, FontStyle.Regular, GraphicsUnit.Pixel);
+            Caption.ForeColor = Color.White;
+            Caption.Location = new Point(241, 39);
+            Caption.Name = "Caption";
+            Caption.Size = new Size(300, 26);
+            Caption.TabIndex = 3;
+            Caption.Text = "Loading";
+            Caption.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // pictureBox1
             // 
-            this.pictureBox1.Image = global::FPIS.Properties.Resources.I_T_S_GH_Logo_White;
-            this.pictureBox1.Location = new System.Drawing.Point(113, 20);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(314, 286);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.pictureBox1.TabIndex = 5;
-            this.pictureBox1.TabStop = false;
+            pictureBox1.Image = Properties.Resources.I_T_S_GH_Logo_White;
+            pictureBox1.Location = new Point(113, 20);
+            pictureBox1.Name = "pictureBox1";
+            pictureBox1.Size = new Size(314, 286);
+            pictureBox1.SizeMode = PictureBoxSizeMode.Zoom;
+            pictureBox1.TabIndex = 5;
+            pictureBox1.TabStop = false;
             // 
             // timer1
             // 
-            this.timer1.Enabled = true;
-            this.timer1.Interval = 500;
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            timer1.Enabled = true;
+            timer1.Interval = 500;
+            timer1.Tick += timer1_Tick;
             // 
             // Startup
             // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(97)))), ((int)(((byte)(46)))));
-            this.ClientSize = new System.Drawing.Size(650, 400);
-            this.Controls.Add(this.panel1);
-            this.ForeColor = System.Drawing.Color.Black;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "Startup";
-            this.Padding = new System.Windows.Forms.Padding(3, 0, 3, 3);
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.ResumeLayout(false);
-
+            AutoScaleMode = AutoScaleMode.None;
+            BackColor = Color.FromArgb(63, 97, 46);
+            ClientSize = new Size(650, 400);
+            Controls.Add(panel1);
+            ForeColor = Color.Black;
+            FormBorderStyle = FormBorderStyle.None;
+            Icon = (Icon)resources.GetObject("$this.Icon");
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "Startup";
+            Padding = new Padding(3, 0, 3, 3);
+            StartPosition = FormStartPosition.CenterScreen;
+            panel1.ResumeLayout(false);
+            panel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).EndInit();
+            ResumeLayout(false);
         }
 
         #endregion

--- a/FPIS/Views/UserControlAddFinishedProduct.Designer.cs
+++ b/FPIS/Views/UserControlAddFinishedProduct.Designer.cs
@@ -42,17 +42,6 @@
             materialTextBoxBatchNumber = new MaterialSkin.Controls.MaterialTextBox();
             materialTextBoxCosignee = new MaterialSkin.Controls.MaterialTextBox();
             dataGridView_Finished_Products_With_Results = new DataGridView();
-            groupBox2 = new GroupBox();
-            materialButton1 = new MaterialSkin.Controls.MaterialButton();
-            materialComboBoxFinishedProduct = new MaterialSkin.Controls.MaterialComboBox();
-            label2 = new Label();
-            groupBox3 = new GroupBox();
-            materialButtonSearchAnalyticalResults = new MaterialSkin.Controls.MaterialButton();
-            label3 = new Label();
-            dateTimePickerToDate = new DateTimePicker();
-            label4 = new Label();
-            dateTimePickerFromDate = new DateTimePicker();
-            materialLabel1 = new MaterialSkin.Controls.MaterialLabel();
             SampleDetailsID = new DataGridViewTextBoxColumn();
             ProductName = new DataGridViewTextBoxColumn();
             ProductType = new DataGridViewTextBoxColumn();
@@ -61,6 +50,18 @@
             AnalysisRequestTime = new DataGridViewTextBoxColumn();
             AnalysisResultDate = new DataGridViewTextBoxColumn();
             AnalysisResultTime = new DataGridViewTextBoxColumn();
+            groupBox2 = new GroupBox();
+            materialButton1 = new MaterialSkin.Controls.MaterialButton();
+            materialComboBoxFinishedProduct = new MaterialSkin.Controls.MaterialComboBox();
+            label2 = new Label();
+            groupBox3 = new GroupBox();
+            materialButtonShowAll = new MaterialSkin.Controls.MaterialButton();
+            materialButtonSearchAnalyticalResults = new MaterialSkin.Controls.MaterialButton();
+            label3 = new Label();
+            dateTimePickerToDate = new DateTimePicker();
+            label4 = new Label();
+            dateTimePickerFromDate = new DateTimePicker();
+            materialLabel1 = new MaterialSkin.Controls.MaterialLabel();
             groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)dataGridView_Finished_Products_With_Results).BeginInit();
             groupBox2.SuspendLayout();
@@ -283,6 +284,73 @@
             dataGridView_Finished_Products_With_Results.TabIndex = 11;
             dataGridView_Finished_Products_With_Results.CellClick += dataGridView_Finished_Products_With_Results_CellClick;
             // 
+            // SampleDetailsID
+            // 
+            SampleDetailsID.HeaderText = "Sample Details ID";
+            SampleDetailsID.MinimumWidth = 6;
+            SampleDetailsID.Name = "SampleDetailsID";
+            SampleDetailsID.ReadOnly = true;
+            SampleDetailsID.Visible = false;
+            SampleDetailsID.Width = 125;
+            // 
+            // ProductName
+            // 
+            ProductName.HeaderText = "Product Name";
+            ProductName.MinimumWidth = 6;
+            ProductName.Name = "ProductName";
+            ProductName.ReadOnly = true;
+            ProductName.Width = 200;
+            // 
+            // ProductType
+            // 
+            ProductType.HeaderText = "Product Type";
+            ProductType.MinimumWidth = 6;
+            ProductType.Name = "ProductType";
+            ProductType.ReadOnly = true;
+            ProductType.Visible = false;
+            ProductType.Width = 125;
+            // 
+            // Label
+            // 
+            Label.HeaderText = "Label";
+            Label.MinimumWidth = 6;
+            Label.Name = "Label";
+            Label.ReadOnly = true;
+            Label.Visible = false;
+            Label.Width = 125;
+            // 
+            // AnalysisRequestDate
+            // 
+            AnalysisRequestDate.HeaderText = "Analysis Request Date";
+            AnalysisRequestDate.MinimumWidth = 6;
+            AnalysisRequestDate.Name = "AnalysisRequestDate";
+            AnalysisRequestDate.ReadOnly = true;
+            AnalysisRequestDate.Width = 163;
+            // 
+            // AnalysisRequestTime
+            // 
+            AnalysisRequestTime.HeaderText = "Analysis Request Time";
+            AnalysisRequestTime.MinimumWidth = 6;
+            AnalysisRequestTime.Name = "AnalysisRequestTime";
+            AnalysisRequestTime.ReadOnly = true;
+            AnalysisRequestTime.Width = 164;
+            // 
+            // AnalysisResultDate
+            // 
+            AnalysisResultDate.HeaderText = "Analysis Result Date";
+            AnalysisResultDate.MinimumWidth = 6;
+            AnalysisResultDate.Name = "AnalysisResultDate";
+            AnalysisResultDate.ReadOnly = true;
+            AnalysisResultDate.Width = 163;
+            // 
+            // AnalysisResultTime
+            // 
+            AnalysisResultTime.HeaderText = "Analysis Result Time";
+            AnalysisResultTime.MinimumWidth = 6;
+            AnalysisResultTime.Name = "AnalysisResultTime";
+            AnalysisResultTime.ReadOnly = true;
+            AnalysisResultTime.Width = 162;
+            // 
             // groupBox2
             // 
             groupBox2.Controls.Add(materialButton1);
@@ -353,6 +421,7 @@
             // 
             // groupBox3
             // 
+            groupBox3.Controls.Add(materialButtonShowAll);
             groupBox3.Controls.Add(materialButtonSearchAnalyticalResults);
             groupBox3.Controls.Add(label3);
             groupBox3.Controls.Add(dateTimePickerToDate);
@@ -365,6 +434,28 @@
             groupBox3.TabStop = false;
             groupBox3.Text = "Search by Analysis Result Date";
             // 
+            // materialButtonShowAll
+            // 
+            materialButtonShowAll.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            materialButtonShowAll.CharacterCasing = MaterialSkin.Controls.MaterialButton.CharacterCasingEnum.Normal;
+            materialButtonShowAll.Cursor = Cursors.Hand;
+            materialButtonShowAll.Density = MaterialSkin.Controls.MaterialButton.MaterialButtonDensity.Default;
+            materialButtonShowAll.Depth = 0;
+            materialButtonShowAll.HighEmphasis = true;
+            materialButtonShowAll.Icon = null;
+            materialButtonShowAll.Location = new Point(762, 36);
+            materialButtonShowAll.Margin = new Padding(5);
+            materialButtonShowAll.MouseState = MaterialSkin.MouseState.HOVER;
+            materialButtonShowAll.Name = "materialButtonShowAll";
+            materialButtonShowAll.NoAccentTextColor = Color.Empty;
+            materialButtonShowAll.Size = new Size(93, 36);
+            materialButtonShowAll.TabIndex = 49;
+            materialButtonShowAll.Text = "Show All";
+            materialButtonShowAll.Type = MaterialSkin.Controls.MaterialButton.MaterialButtonType.Contained;
+            materialButtonShowAll.UseAccentColor = true;
+            materialButtonShowAll.UseVisualStyleBackColor = true;
+            materialButtonShowAll.Click += materialButtonShowAll_Click;
+            // 
             // materialButtonSearchAnalyticalResults
             // 
             materialButtonSearchAnalyticalResults.AutoSizeMode = AutoSizeMode.GrowAndShrink;
@@ -374,7 +465,7 @@
             materialButtonSearchAnalyticalResults.Depth = 0;
             materialButtonSearchAnalyticalResults.HighEmphasis = true;
             materialButtonSearchAnalyticalResults.Icon = null;
-            materialButtonSearchAnalyticalResults.Location = new Point(698, 36);
+            materialButtonSearchAnalyticalResults.Location = new Point(665, 36);
             materialButtonSearchAnalyticalResults.Margin = new Padding(5);
             materialButtonSearchAnalyticalResults.MouseState = MaterialSkin.MouseState.HOVER;
             materialButtonSearchAnalyticalResults.Name = "materialButtonSearchAnalyticalResults";
@@ -390,7 +481,7 @@
             // label3
             // 
             label3.AutoSize = true;
-            label3.Location = new Point(378, 51);
+            label3.Location = new Point(350, 51);
             label3.Name = "label3";
             label3.Size = new Size(32, 20);
             label3.TabIndex = 48;
@@ -398,7 +489,7 @@
             // 
             // dateTimePickerToDate
             // 
-            dateTimePickerToDate.Location = new Point(417, 47);
+            dateTimePickerToDate.Location = new Point(389, 47);
             dateTimePickerToDate.Name = "dateTimePickerToDate";
             dateTimePickerToDate.Size = new Size(250, 27);
             dateTimePickerToDate.TabIndex = 47;
@@ -406,7 +497,7 @@
             // label4
             // 
             label4.AutoSize = true;
-            label4.Location = new Point(45, 51);
+            label4.Location = new Point(17, 51);
             label4.Name = "label4";
             label4.Size = new Size(50, 20);
             label4.TabIndex = 45;
@@ -414,7 +505,7 @@
             // 
             // dateTimePickerFromDate
             // 
-            dateTimePickerFromDate.Location = new Point(101, 47);
+            dateTimePickerFromDate.Location = new Point(73, 47);
             dateTimePickerFromDate.Name = "dateTimePickerFromDate";
             dateTimePickerFromDate.Size = new Size(250, 27);
             dateTimePickerFromDate.TabIndex = 44;
@@ -431,73 +522,6 @@
             materialLabel1.Size = new Size(191, 24);
             materialLabel1.TabIndex = 15;
             materialLabel1.Text = "Add Finished Product";
-            // 
-            // SampleDetailsID
-            // 
-            SampleDetailsID.HeaderText = "Sample Details ID";
-            SampleDetailsID.MinimumWidth = 6;
-            SampleDetailsID.Name = "SampleDetailsID";
-            SampleDetailsID.ReadOnly = true;
-            SampleDetailsID.Visible = false;
-            SampleDetailsID.Width = 125;
-            // 
-            // ProductName
-            // 
-            ProductName.HeaderText = "Product Name";
-            ProductName.MinimumWidth = 6;
-            ProductName.Name = "ProductName";
-            ProductName.ReadOnly = true;
-            ProductName.Width = 200;
-            // 
-            // ProductType
-            // 
-            ProductType.HeaderText = "Product Type";
-            ProductType.MinimumWidth = 6;
-            ProductType.Name = "ProductType";
-            ProductType.ReadOnly = true;
-            ProductType.Visible = false;
-            ProductType.Width = 125;
-            // 
-            // Label
-            // 
-            Label.HeaderText = "Label";
-            Label.MinimumWidth = 6;
-            Label.Name = "Label";
-            Label.ReadOnly = true;
-            Label.Visible = false;
-            Label.Width = 125;
-            // 
-            // AnalysisRequestDate
-            // 
-            AnalysisRequestDate.HeaderText = "Analysis Request Date";
-            AnalysisRequestDate.MinimumWidth = 6;
-            AnalysisRequestDate.Name = "AnalysisRequestDate";
-            AnalysisRequestDate.ReadOnly = true;
-            AnalysisRequestDate.Width = 163;
-            // 
-            // AnalysisRequestTime
-            // 
-            AnalysisRequestTime.HeaderText = "Analysis Request Time";
-            AnalysisRequestTime.MinimumWidth = 6;
-            AnalysisRequestTime.Name = "AnalysisRequestTime";
-            AnalysisRequestTime.ReadOnly = true;
-            AnalysisRequestTime.Width = 164;
-            // 
-            // AnalysisResultDate
-            // 
-            AnalysisResultDate.HeaderText = "Analysis Result Date";
-            AnalysisResultDate.MinimumWidth = 6;
-            AnalysisResultDate.Name = "AnalysisResultDate";
-            AnalysisResultDate.ReadOnly = true;
-            AnalysisResultDate.Width = 163;
-            // 
-            // AnalysisResultTime
-            // 
-            AnalysisResultTime.HeaderText = "Analysis Result Time";
-            AnalysisResultTime.MinimumWidth = 6;
-            AnalysisResultTime.Name = "AnalysisResultTime";
-            AnalysisResultTime.ReadOnly = true;
-            AnalysisResultTime.Width = 162;
             // 
             // UserControlAddFinishedProduct
             // 
@@ -557,5 +581,6 @@
         private DataGridViewTextBoxColumn AnalysisRequestTime;
         private DataGridViewTextBoxColumn AnalysisResultDate;
         private DataGridViewTextBoxColumn AnalysisResultTime;
+        private MaterialSkin.Controls.MaterialButton materialButtonShowAll;
     }
 }

--- a/FPIS/Views/UserControlCheckAnalyticalResults.cs
+++ b/FPIS/Views/UserControlCheckAnalyticalResults.cs
@@ -30,7 +30,7 @@ namespace FPIS.Views
             InitializeComponent();
             dataGridView_Finished_Products_With_Results.DataSource = sampleDetailsList;
             // dataGridView1.DataSource = parameterResultList;
-            LoadAnalyticalResults();
+            LoadAnalyticalResultsForToday();
 
             //labelAnalysisRemarkError.ForeColor = System.Drawing.Color.Red;
 
@@ -149,6 +149,69 @@ namespace FPIS.Views
             }
 
             CountAnalysisRequests(totalNumberOfRequests);
+        }
+
+        private void LoadAnalyticalResultsForToday()
+        {
+            ClearErrorLabels();
+            int totalNumberOfRequests = 0;
+            if (materialRadioButtonProductAnalysis.Checked)
+            {
+                List<SampleDetail> samplesDetails = new ProductService(new()).GetProductsWithAnalysisResultsForToday(DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")), DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")));
+                sampleDetailsList.Clear();
+                foreach (SampleDetail sampleDetail in samplesDetails)
+                {
+                    CheckAnalyticalResultsBindingItem sampleDetailItem = new CheckAnalyticalResultsBindingItem();
+                    sampleDetailItem.AnalysisItem = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductName;
+                    sampleDetailItem.SampleDetailLabel = sampleDetail.Label;
+                    sampleDetailItem.SampleDetailId = sampleDetail.Id;
+                    sampleDetailItem.ProductName = $"{sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductName} {sampleDetail.Label}";
+                    sampleDetailItem.ProductType = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.Type;
+                    sampleDetailItem.AnalysisType = sampleDetail.Sample.TypeForFiltering;
+                    sampleDetailItem.AnalysisRequestDate = sampleDetail.Sample.Date.ToLongDateString();
+                    sampleDetailItem.AnalysisRequestTime = sampleDetail.Sample.Time.ToLongTimeString();
+                    //sampleDetailItem.AnalysisResultDate = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.SampleResult.Date.ToLongDateString();
+                    sampleDetailItem.AnalysisResultDate = sampleDetail.Sample.SampleResults.FirstOrDefault().Date.ToLongDateString();
+                    //sampleDetailItem.AnalysisResultTime = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.SampleResult.Time.ToLongTimeString();
+                    sampleDetailItem.AnalysisResultTime = sampleDetail.Sample.SampleResults.FirstOrDefault().Time.ToLongTimeString();
+                    //sampleDetailItem.SampleResultId = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.SampleResult.Id.ToString();
+                    //sampleDetailItem.SampleResultId = sampleDetail.Sample.SampleResults.FirstOrDefault().Id.ToString();
+                    sampleDetailItem.SampleDetailsId = sampleDetail.Id.ToString();
+                    sampleDetailItem.SampleResultId = sampleDetail.Sample.SampleResults.FirstOrDefault().Id.ToString();
+                    sampleDetailItem.SampleResultDetailsId = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.Id.ToString(); ;
+                    totalNumberOfRequests++;
+                    sampleDetailsList.Add(sampleDetailItem);
+                }
+            }
+            else
+            {
+                List<SampleDetail> samplesDetails = new WaterService(new()).GetWatersWithAnalysisResultsForToday(DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")), DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")));
+                sampleDetailsList.Clear();
+                foreach (SampleDetail sampleDetail in samplesDetails)
+                {
+                    CheckAnalyticalResultsBindingItem sampleDetailItem = new CheckAnalyticalResultsBindingItem();
+                    sampleDetailItem.AnalysisItem = sampleDetail.AnalysisItem.AnalysisWaters.FirstOrDefault().Water.WaterName;
+                    sampleDetailItem.SampleDetailLabel = sampleDetail.Label;
+                    sampleDetailItem.SampleDetailId = sampleDetail.Id;
+                    sampleDetailItem.ProductName = $"{sampleDetail.AnalysisItem.AnalysisWaters.FirstOrDefault().Water.WaterName} {sampleDetail.Label}";
+                    sampleDetailItem.AnalysisType = sampleDetail.Sample.TypeForFiltering;
+                    sampleDetailItem.AnalysisRequestDate = sampleDetail.Sample.Date.ToLongDateString();
+                    sampleDetailItem.AnalysisRequestTime = sampleDetail.Sample.Time.ToLongTimeString();
+                    //sampleDetailItem.AnalysisResultDate = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.SampleResult.Date.ToLongDateString();
+                    sampleDetailItem.AnalysisResultDate = sampleDetail.Sample.SampleResults.FirstOrDefault().Date.ToLongDateString();
+                    //sampleDetailItem.AnalysisResultTime = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.SampleResult.Time.ToLongTimeString();
+                    sampleDetailItem.AnalysisResultTime = sampleDetail.Sample.SampleResults.FirstOrDefault().Time.ToLongTimeString();
+                    //sampleDetailItem.SampleResultId = sampleDetail.AnalysisItem.AnalysisProducts.FirstOrDefault().Product.ProductParameters.FirstOrDefault().ProductAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.SampleResult.Id.ToString();
+                    //sampleDetailItem.SampleResultId = sampleDetail.Sample.SampleResults.FirstOrDefault().Id.ToString();
+                    sampleDetailItem.SampleDetailsId = sampleDetail.Id.ToString();
+                    sampleDetailItem.SampleResultId = sampleDetail.Sample.SampleResults.FirstOrDefault().Id.ToString();
+                    sampleDetailItem.SampleResultDetailsId = sampleDetail.AnalysisItem.AnalysisWaters.FirstOrDefault().Water.WaterParameters.FirstOrDefault().WaterAnalysisParameters.FirstOrDefault().AnalysisParameter.sampleResultsDetailsWithParameters.FirstOrDefault().SampleResultDetail.Id.ToString(); ;
+                    totalNumberOfRequests++;
+                    sampleDetailsList.Add(sampleDetailItem);
+                }
+            }
+            CountAnalysisRequests(totalNumberOfRequests);
+            EnableTimeFilter();
         }
 
         private void LoadAnalyticalResultsPerDate()
@@ -399,11 +462,12 @@ namespace FPIS.Views
                                          specification_range = $"{((ProductParameter.Specification == "0") ? "-" : ProductParameter.MinimumSpecification == null ? "<= " + ProductParameter.Specification : ProductParameter.MinimumSpecification + " - " + ProductParameter.Specification)}",
                                          specification = ProductParameter.Specification,
                                          result = $"{(SampleResultsDetailsWithParameter.Value == null ? "-" : SampleResultsDetailsWithParameter.Value)}",
-                                         variance = $"{(SampleResultsDetailsWithParameter.Value == null ? "-" : (SampleResultsDetailsWithParameter.Value.Length >= 5) ? "-" : (float)Math.Round(Convert.ToDecimal(float.Parse(ProductParameter.Specification) - float.Parse(SampleResultsDetailsWithParameter.Value)), 2))}",
-                                         variance2 = $"{(SampleResultsDetailsWithParameter.Value == null ? "-" : (SampleResultsDetailsWithParameter.Value.Length >= 5) ? "-" : (float)Math.Round(Convert.ToDecimal(float.Parse(SampleResultsDetailsWithParameter.Value) - ProductParameter.MinimumSpecification), 2))}",
+                                         variance = $"{(SampleResultsDetailsWithParameter.Value == null ? "-" : (SampleResultsDetailsWithParameter.Value.Length >= 5) ? "-" : (SampleResultsDetailsWithParameter.Value == "-") ? "-" : (float)Math.Round(Convert.ToDecimal(float.Parse(ProductParameter.Specification) - float.Parse(SampleResultsDetailsWithParameter.Value)), 2))}",
+                                         variance2 = $"{(SampleResultsDetailsWithParameter.Value == null ? "-" : (SampleResultsDetailsWithParameter.Value.Length >= 5) ? "-" : (SampleResultsDetailsWithParameter.Value == "-") ? "-" : (float)Math.Round(Convert.ToDecimal(float.Parse(SampleResultsDetailsWithParameter.Value) - ProductParameter.MinimumSpecification), 2))}",
                                          //indicator = "",
                                          indicator = $"{(SampleResultsDetailsWithParameter.Value == null ? "-" : (SampleResultsDetailsWithParameter.Value.Length >= 5) ? "-" : "")}",
                                          remarks = $"{(SampleResultsDetailsWithParameter.Remarks == null ? "" : SampleResultsDetailsWithParameter.Remarks)}"
+
                                      };
                 dataGridView1.Rows.Clear();
                 foreach (var items in analysisResult.Distinct())
@@ -918,7 +982,7 @@ namespace FPIS.Views
 
         private void materialRadioButtonProductAnalysis_CheckedChanged(object sender, EventArgs e)
         {
-            LoadAnalyticalResults();
+            LoadAnalyticalResultsForToday();
             dataGridView1.Rows.Clear();
             //materialButtonSaveAnalysisRemark.Enabled = false;
             materialButtonPrintAnalyticalResult.Enabled = false;
@@ -928,7 +992,7 @@ namespace FPIS.Views
 
         private void materialRadioButtonWaterAnalysis_CheckedChanged(object sender, EventArgs e)
         {
-            LoadAnalyticalResults();
+            LoadAnalyticalResultsForToday();
             dataGridView1.Rows.Clear();
             //materialButtonSaveAnalysisRemark.Enabled = false;
             materialButtonPrintAnalyticalResult.Enabled = false;

--- a/FPIS/Views/UserControlViewSampleResults.cs
+++ b/FPIS/Views/UserControlViewSampleResults.cs
@@ -18,7 +18,7 @@ namespace FPIS.Views
             _analysisService = new(dbContext);
             _userService = new(dbContext);
 
-            FetchAnalysisResults();
+            FetchAnalysisResultsForToday();
             DisableTimeFilter();
             
         }
@@ -54,6 +54,65 @@ namespace FPIS.Views
             else
             {
                 _sampleResults = _analysisService.FetchWaterSampleResults()
+                .Select(sr =>
+                {
+                    User prodEngineer1 = _userService.GetUserByEmployeeId(sr.Sample.Employee1);
+                    User prodEngineer2 = _userService.GetUserByEmployeeId(sr.Sample.Employee2);
+                    AnalysisResultDataBindingItem u = new()
+                    {
+                        ProductionEngineerOne = $"{prodEngineer2?.FirstName} {prodEngineer2?.LastName}",
+                        ProductionEngineerTwo = $"{prodEngineer1?.FirstName} {prodEngineer1?.LastName}",
+                        SampleResultId = sr.Id.ToString(),
+                        Name = $"{sr.User.FirstName} {sr.User.MiddleName} {sr.User.LastName}",
+                        AnalysisType = sr.Sample.TypeForFiltering,
+                        ResultDate = $"{sr.Date.ToLongDateString()} @ {sr.Time.ToShortTimeString()}",
+                        Sample = $"{sr.Sample.Date.ToLongDateString()} @ {sr.Sample.Time.ToShortTimeString()}"
+                    };
+
+                    return u;
+                })
+                .ToList();
+
+                dataGridView1.DataSource = _sampleResults;
+
+                //labelSampleResultsTotal.Text = _sampleResults?.Count().ToString() ?? "No results available";
+                labelSampleResultsTotal.Text = _sampleResults?.Count() == 0 ? "No results available" : ($"{_sampleResults?.Count()} result{((_sampleResults?.Count() > 1) ? "s" : "")} available");
+            }
+        }
+
+
+        void FetchAnalysisResultsForToday()
+        {
+            if (materialRadioButtonProductAnalysis.Checked)
+            {
+                _sampleResults = _analysisService.FetchProductSampleResultsForToday(DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")), DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")))
+                .Select(sr =>
+                {
+                    User prodEngineer1 = _userService.GetUserByEmployeeId(sr.Sample.Employee1);
+                    User prodEngineer2 = _userService.GetUserByEmployeeId(sr.Sample.Employee2);
+                    AnalysisResultDataBindingItem u = new()
+                    {
+                        ProductionEngineerOne = $"{prodEngineer2?.FirstName} {prodEngineer2?.LastName}",
+                        ProductionEngineerTwo = $"{prodEngineer1?.FirstName} {prodEngineer1?.LastName}",
+                        SampleResultId = sr.Id.ToString(),
+                        Name = $"{sr.User.FirstName} {sr.User.MiddleName} {sr.User.LastName}",
+                        AnalysisType = sr.Sample.TypeForFiltering,
+                        ResultDate = $"{sr.Date.ToLongDateString()} @ {sr.Time.ToShortTimeString()}",
+                        Sample = $"{sr.Sample.Date.ToLongDateString()} @ {sr.Sample.Time.ToShortTimeString()}"
+                    };
+
+                    return u;
+                })
+                .ToList();
+
+                dataGridView1.DataSource = _sampleResults;
+
+                //labelSampleResultsTotal.Text = _sampleResults?.Count().ToString() ?? "No results available";
+                labelSampleResultsTotal.Text = _sampleResults?.Count() == 0 ? "No results available" : ($"{_sampleResults?.Count()} result{((_sampleResults?.Count() > 1) ? "s" : "")} available");
+            }
+            else
+            {
+                _sampleResults = _analysisService.FetchWaterSampleResultsForToday(DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")), DateOnly.Parse(DateTime.Now.ToString("MM/dd/yyyy")))
                 .Select(sr =>
                 {
                     User prodEngineer1 = _userService.GetUserByEmployeeId(sr.Sample.Employee1);
@@ -231,13 +290,13 @@ namespace FPIS.Views
         private void materialRadioButtonProductAnalysis_CheckedChanged(object sender, EventArgs e)
         {
             DisableTimeFilter();
-            FetchAnalysisResults();
+            FetchAnalysisResultsForToday();
         }
 
         private void materialRadioButtonWaterAnalysis_CheckedChanged(object sender, EventArgs e)
         {
             DisableTimeFilter();
-            FetchAnalysisResults();
+            FetchAnalysisResultsForToday();
         }
 
         private void materialButtonSearchAnalyticalResults_Click(object sender, EventArgs e)

--- a/Reporting/RDLCReports/CertificateOfAnalysis.rdlc
+++ b/Reporting/RDLCReports/CertificateOfAnalysis.rdlc
@@ -104,7 +104,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox1</rd:DefaultName>
-            <Top>0.68556in</Top>
+            <Top>1.43556in</Top>
             <Left>2.30416in</Left>
             <Height>0.45in</Height>
             <Width>3.39167in</Width>
@@ -135,7 +135,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>1.09667in</Top>
+            <Top>1.84667in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1in</Width>
@@ -167,7 +167,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>1.40222in</Top>
+            <Top>2.15222in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1in</Width>
@@ -199,7 +199,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>1.72167in</Top>
+            <Top>2.47167in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1in</Width>
@@ -231,7 +231,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.04111in</Top>
+            <Top>2.79111in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1in</Width>
@@ -263,7 +263,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.36056in</Top>
+            <Top>3.11056in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1.24167in</Width>
@@ -295,7 +295,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.68in</Top>
+            <Top>3.43in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1in</Width>
@@ -327,7 +327,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.99944in</Top>
+            <Top>3.74944in</Top>
             <Left>0.805in</Left>
             <Height>0.25in</Height>
             <Width>1in</Width>
@@ -359,7 +359,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>1.09667in</Top>
+            <Top>1.84667in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -391,7 +391,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>1.41611in</Top>
+            <Top>2.16611in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -423,7 +423,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>1.73556in</Top>
+            <Top>2.48556in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -455,7 +455,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.04111in</Top>
+            <Top>2.79111in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -487,7 +487,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.36056in</Top>
+            <Top>3.11056in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -519,7 +519,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.68in</Top>
+            <Top>3.43in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -551,7 +551,7 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>2.99944in</Top>
+            <Top>3.74944in</Top>
             <Left>2.25in</Left>
             <Height>0.25in</Height>
             <Width>2.71333in</Width>
@@ -973,7 +973,7 @@
               </TablixMembers>
             </TablixRowHierarchy>
             <DataSetName>Analysis_Result_Dataset</DataSetName>
-            <Top>3.405in</Top>
+            <Top>4.155in</Top>
             <Left>0.75708in</Left>
             <Height>0.5in</Height>
             <Width>6.48583in</Width>
@@ -986,21 +986,6 @@
               <VerticalAlign>Middle</VerticalAlign>
             </Style>
           </Tablix>
-          <Image Name="Image1">
-            <Source>Embedded</Source>
-            <Value>FujiOilLogo</Value>
-            <Sizing>FitProportional</Sizing>
-            <Top>0.13556in</Top>
-            <Left>2.83in</Left>
-            <Height>0.34722in</Height>
-            <Width>3.18333in</Width>
-            <ZIndex>16</ZIndex>
-            <Style>
-              <Border>
-                <Style>None</Style>
-              </Border>
-            </Style>
-          </Image>
           <Textbox Name="Textbox54">
             <CanGrow>true</CanGrow>
             <KeepTogether>true</KeepTogether>
@@ -1018,11 +1003,11 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox54</rd:DefaultName>
-            <Top>4.18in</Top>
+            <Top>8.18in</Top>
             <Left>0.73833in</Left>
             <Height>0.25in</Height>
             <Width>3.06667in</Width>
-            <ZIndex>17</ZIndex>
+            <ZIndex>16</ZIndex>
             <Style>
               <Border>
                 <Style>None</Style>
@@ -1050,11 +1035,11 @@
               </Paragraph>
             </Paragraphs>
             <rd:DefaultName>Textbox12</rd:DefaultName>
-            <Top>4.43in</Top>
+            <Top>8.43in</Top>
             <Left>0.75708in</Left>
             <Height>0.25in</Height>
             <Width>1.69167in</Width>
-            <ZIndex>18</ZIndex>
+            <ZIndex>17</ZIndex>
             <Style>
               <Border>
                 <Style>None</Style>
@@ -1066,7 +1051,7 @@
             </Style>
           </Textbox>
         </ReportItems>
-        <Height>5.43in</Height>
+        <Height>9.31333in</Height>
         <Style>
           <Border>
             <Style>None</Style>
@@ -1079,42 +1064,6 @@
           <Height>1in</Height>
           <PrintOnFirstPage>true</PrintOnFirstPage>
           <PrintOnLastPage>true</PrintOnLastPage>
-          <ReportItems>
-            <Textbox Name="Textbox3">
-              <CanGrow>true</CanGrow>
-              <KeepTogether>true</KeepTogether>
-              <Paragraphs>
-                <Paragraph>
-                  <TextRuns>
-                    <TextRun>
-                      <Value>Fractionation Process Integration System (FPIS) - Fuji Oil Ghana Ltd.</Value>
-                      <Style>
-                        <FontSize>8pt</FontSize>
-                        <FontWeight>Bold</FontWeight>
-                      </Style>
-                    </TextRun>
-                  </TextRuns>
-                  <Style>
-                    <TextAlign>Left</TextAlign>
-                  </Style>
-                </Paragraph>
-              </Paragraphs>
-              <rd:DefaultName>Textbox3</rd:DefaultName>
-              <Top>0.75in</Top>
-              <Left>0.11208in</Left>
-              <Height>0.25in</Height>
-              <Width>4.37584in</Width>
-              <Style>
-                <Border>
-                  <Style>None</Style>
-                </Border>
-                <PaddingLeft>2pt</PaddingLeft>
-                <PaddingRight>2pt</PaddingRight>
-                <PaddingTop>2pt</PaddingTop>
-                <PaddingBottom>2pt</PaddingBottom>
-              </Style>
-            </Textbox>
-          </ReportItems>
           <Style>
             <Border>
               <Style>None</Style>


### PR DESCRIPTION
Initially, when checking the analytical results, the system by default will fetch all the analytical results in the database.
This made the system to be slow since there are over thousands of analytical results.

The same thing occurs when updating a particular sample result.
Also, when adding a finished product, the system by default does the same thing.

This PR contains the following features added to modify the default data the system fetches

*  When a user wants to view analytical results, the system will only show analytical results for the current day by default.
* When a user wants to update a sample result, the system by default will only show results for the current day.
* When a user wants to add a finished product, the system will show only finished products that were analysed  on the current day by default.

Above all, the user will then have filters to search by range or fetch everything.